### PR TITLE
Add cursor showcase example with tab switch

### DIFF
--- a/examples/CursorShowcase.tsx
+++ b/examples/CursorShowcase.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { CursorWrapper, CursorVariant } from '../src';
+
+const variants: CursorVariant[] = ['default', 'dot', 'arrow', 'circle', 'pointer'];
+
+const boxStyle: React.CSSProperties = {
+  position: 'relative',
+  width: '160px',
+  height: '160px',
+  border: '1px solid #ddd',
+  borderRadius: '8px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden'
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: '6px 10px',
+  borderRadius: '4px',
+  border: '1px solid #ccc',
+  background: '#f5f5f5',
+  cursor: 'pointer'
+};
+
+const labelStyle: React.CSSProperties = {
+  position: 'absolute',
+  bottom: '8px',
+  left: 0,
+  right: 0,
+  textAlign: 'center',
+  fontSize: '14px',
+  fontWeight: 600,
+  pointerEvents: 'none'
+};
+
+const CursorPreview: React.FC<{ variant: CursorVariant }> = ({ variant }) => {
+  const [active, setActive] = useState(false);
+  const targetId = `preview-${variant}`;
+
+  useEffect(() => {
+    setActive(true);
+    const interval = setInterval(() => {
+      setActive(false);
+      setTimeout(() => setActive(true), 50);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div style={boxStyle}>
+      <button id={targetId} style={buttonStyle}>Click</button>
+      <CursorWrapper
+        variant={variant}
+        isActive={active}
+        action={{ type: 'click', target: `#${targetId}`, delay: 200 }}
+      />
+      <div style={labelStyle}>{variant}</div>
+    </div>
+  );
+};
+
+const CursorShowcase: React.FC = () => {
+  return (
+    <div style={{ display: 'grid', gap: '20px', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', padding: '20px' }}>
+      {variants.map(v => (
+        <CursorPreview key={v} variant={v} />
+      ))}
+    </div>
+  );
+};
+
+export default CursorShowcase;

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,10 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import ComprehensiveDemo from './ComprehensiveDemo';
+import CursorShowcase from './CursorShowcase';
+
+const tabButton = (active) => ({
+  padding: '8px 16px',
+  border: 'none',
+  borderBottom: active ? '2px solid #3498db' : '2px solid transparent',
+  background: 'transparent',
+  cursor: 'pointer',
+  fontWeight: active ? 'bold' : 'normal'
+});
+
+const App = () => {
+  const [tab, setTab] = useState('demo');
+  return (
+    <div style={{ maxWidth: '900px', margin: '0 auto' }}>
+      <div style={{ display: 'flex', gap: '10px', borderBottom: '1px solid #ddd', marginBottom: '20px' }}>
+        <button style={tabButton(tab === 'demo')} onClick={() => setTab('demo')}>Comprehensive Demo</button>
+        <button style={tabButton(tab === 'cursors')} onClick={() => setTab('cursors')}>Cursor Showcase</button>
+      </div>
+      {tab === 'demo' ? <ComprehensiveDemo /> : <CursorShowcase />}
+    </div>
+  );
+};
 
 const root = createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <ComprehensiveDemo />
+    <App />
   </React.StrictMode>
-); 
+);


### PR DESCRIPTION
## Summary
- add a new `CursorShowcase` example
- update example entry to include a tabbed interface with the showcase

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e6f492738832282d701132be1dc4b