### PR TITLE
Add visual feedback color options

### DIFF
--- a/examples/CursorShowcase.tsx
+++ b/examples/CursorShowcase.tsx
@@ -63,7 +63,11 @@ const CursorPreview: React.FC<{ variant: CursorVariant }> = ({ variant }) => {
 
 const CursorShowcase: React.FC = () => {
   return (
-    <DemoProvider steps={[]}>
+    <DemoProvider
+      steps={[]}
+      clickInactiveColor="#e0e0e0"
+      clickActiveColor="#4caf50"
+    >
       <div style={{ display: 'grid', gap: '20px', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', padding: '20px' }}>
         {variants.map(v => (
           <CursorPreview key={v} variant={v} />

--- a/src/Demo.tsx
+++ b/src/Demo.tsx
@@ -145,6 +145,8 @@ export const Demo: React.FC<DemoProps> = ({
   defaultFadeOutDuration = DEFAULT_FADE_OUT_DURATION,
   defaultFadeInEasing,
   defaultFadeOutEasing,
+  visualClickInactiveColor,
+  visualClickActiveColor,
   onStepComplete,
   onComplete,
 }) => {
@@ -153,6 +155,8 @@ export const Demo: React.FC<DemoProps> = ({
         steps={steps}
         autoPlay={autoPlay}
         loop={loop}
+        clickInactiveColor={visualClickInactiveColor}
+        clickActiveColor={visualClickActiveColor}
         onStepComplete={onStepComplete}
         onComplete={onComplete}
       >

--- a/src/DemoContext.tsx
+++ b/src/DemoContext.tsx
@@ -7,6 +7,10 @@ interface DemoProviderProps {
   steps: DemoStep[];
   autoPlay?: boolean;
   loop?: boolean;
+  /** Color of a button when not clicked during visual feedback */
+  clickInactiveColor?: string;
+  /** Color of a button while it is being clicked */
+  clickActiveColor?: string;
   onStepComplete?: (stepId: string) => void;
   onComplete?: () => void;
   children: React.ReactNode;
@@ -33,6 +37,8 @@ export const DemoProvider: React.FC<DemoProviderProps> = ({
   steps,
   autoPlay = false,
   loop = false,
+  clickInactiveColor = '#f5f5f5',
+  clickActiveColor = '#357ae8',
   onStepComplete,
   onComplete,
   children,
@@ -241,8 +247,19 @@ export const DemoProvider: React.FC<DemoProviderProps> = ({
               const originalBg = element.style.backgroundColor;
               const originalTransform = element.style.transform;
               
-              // Apply pressed effect
-              element.style.backgroundColor = 'var(--button-active-bg, #357ae8)';
+              // Ensure a base color when not clicked
+              if (!element.style.backgroundColor) {
+                element.style.backgroundColor = clickInactiveColor;
+                applyElementModification({
+                  selector,
+                  type: 'style',
+                  name: 'backgroundColor',
+                  value: clickInactiveColor
+                }, element);
+              }
+
+              // Apply pressed effect with provided active color
+              element.style.backgroundColor = clickActiveColor;
               element.style.transform = 'scale(0.98)';
               
               // Store the visual changes
@@ -250,7 +267,7 @@ export const DemoProvider: React.FC<DemoProviderProps> = ({
                 selector,
                 type: 'style',
                 name: 'backgroundColor',
-                value: 'var(--button-active-bg, #357ae8)'
+                value: clickActiveColor
               }, element);
               
               applyElementModification({
@@ -265,7 +282,7 @@ export const DemoProvider: React.FC<DemoProviderProps> = ({
                 if (originalBg) {
                   element.style.backgroundColor = originalBg;
                 } else {
-                  element.style.removeProperty('background-color');
+                  element.style.backgroundColor = clickInactiveColor;
                 }
                 
                 if (originalTransform) {
@@ -299,7 +316,7 @@ export const DemoProvider: React.FC<DemoProviderProps> = ({
         resolve(false);
       }
     });
-  }, [findElement, applyElementModification]);
+  }, [findElement, applyElementModification, clickInactiveColor, clickActiveColor]);
 
   // Handle state changes for elements (expanded, collapsed, etc.)
   const handleElementState = useCallback((selector: string, stateName: string, stateValue: boolean): Promise<boolean> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,9 @@ export interface DemoProps {
   cursorSize?: number;
   cursorColor?: string;
   cursorVariant?: string; // Type of cursor to display
+  // Colors for visual feedback clicking
+  visualClickInactiveColor?: string;
+  visualClickActiveColor?: string;
   defaultTransitionDirection?: 'x' | 'y'; // default direction for all steps
   defaultEasing?: (t: number) => number; // default easing function for all steps
   defaultFadeInDuration?: number; // default fade in duration for all steps


### PR DESCRIPTION
## Summary
- allow passing `clickInactiveColor` and `clickActiveColor` to `DemoProvider`
- pass these props through `Demo` component
- document new props in type definitions
- update the cursor showcase example to demonstrate new colors

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e76e8c4b48322906210ae5acde57a