### PR TITLE
Add mock browser feature with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 - [ ] Mac cursor
 - [ ] Automatic scrolling
 - [ ] Stop scrolling at
-- [ ] Mock Browser Window
+- [x] Mock Browser Window

--- a/examples/BrowserDemo.tsx
+++ b/examples/BrowserDemo.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Demo, createStep, MockBrowser, BrowserType } from '../src';
+
+const BrowserDemo: React.FC = () => {
+  const [browser, setBrowser] = useState<BrowserType>('chrome');
+  const steps = [
+    createStep({
+      name: 'Welcome',
+      content: (
+        <div className="demo-step">
+          <h2>Mock Browser Demo</h2>
+          <p>Select a browser style using the dropdown below.</p>
+        </div>
+      ),
+      duration: 3000,
+    }),
+    createStep({
+      name: 'Second',
+      content: (
+        <div className="demo-step">
+          <p>The demo is running inside a simulated browser frame.</p>
+        </div>
+      ),
+      duration: 3000,
+    }),
+  ];
+
+  return (
+    <div style={{ padding: '20px', textAlign: 'center' }}>
+      <select value={browser} onChange={(e) => setBrowser(e.target.value as BrowserType)} style={{ marginBottom: '10px' }}>
+        <option value="chrome">Chrome</option>
+        <option value="safari">Safari</option>
+        <option value="ios-safari">iOS Safari (mobile)</option>
+        <option value="android-chrome">Android Chrome (mobile)</option>
+      </select>
+      <MockBrowser type={browser} style={{ marginTop: 10 }}>
+        <Demo steps={steps} autoPlay loop={false} />
+      </MockBrowser>
+    </div>
+  );
+};
+
+export default BrowserDemo;

--- a/examples/index.js
+++ b/examples/index.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import ComprehensiveDemo from './ComprehensiveDemo';
 import CursorShowcase from './CursorShowcase';
+import BrowserDemo from './BrowserDemo';
 
 const tabButton = (active) => ({
   padding: '8px 16px',
@@ -19,8 +20,11 @@ const App = () => {
       <div style={{ display: 'flex', gap: '10px', borderBottom: '1px solid #ddd', marginBottom: '20px' }}>
         <button style={tabButton(tab === 'demo')} onClick={() => setTab('demo')}>Comprehensive Demo</button>
         <button style={tabButton(tab === 'cursors')} onClick={() => setTab('cursors')}>Cursor Showcase</button>
+        <button style={tabButton(tab === 'browser')} onClick={() => setTab('browser')}>Browser Demo</button>
       </div>
-      {tab === 'demo' ? <ComprehensiveDemo /> : <CursorShowcase />}
+      {tab === 'demo' && <ComprehensiveDemo />}
+      {tab === 'cursors' && <CursorShowcase />}
+      {tab === 'browser' && <BrowserDemo />}
     </div>
   );
 };

--- a/src/MockBrowser.tsx
+++ b/src/MockBrowser.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+export type BrowserType =
+  | 'safari'
+  | 'chrome'
+  | 'ios-safari'
+  | 'android-chrome';
+
+export interface MockBrowserProps {
+  type?: BrowserType;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+export const MockBrowser: React.FC<MockBrowserProps> = ({
+  type = 'chrome',
+  style = {},
+  children,
+}) => {
+  const isMobile = type === 'ios-safari' || type === 'android-chrome';
+  const borderRadius = isMobile ? 20 : 8;
+
+  const headerStyle: React.CSSProperties = {
+    height: isMobile ? 40 : 28,
+    background: '#f2f2f2',
+    borderBottom: '1px solid #ddd',
+    display: 'flex',
+    alignItems: 'center',
+    padding: isMobile ? '0 12px' : '0 8px',
+    gap: 6,
+  };
+
+  const dot = (color: string) => (
+    <div
+      style={{
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        background: color,
+      }}
+    />
+  );
+
+  return (
+    <div
+      style={{
+        border: '1px solid #ccc',
+        borderRadius,
+        overflow: 'hidden',
+        width: isMobile ? 375 : '100%',
+        margin: '0 auto',
+        ...style,
+      }}
+    >
+      <div style={headerStyle}>
+        {isMobile ? (
+          <div style={{ flex: 1, textAlign: 'center', fontSize: 12 }}>
+            {type === 'ios-safari' ? 'Safari' : 'Chrome'}
+          </div>
+        ) : (
+          <div style={{ display: 'flex', gap: 4 }}>
+            {dot('#ff5f57')}
+            {dot('#febc2e')}
+            {dot('#28c840')}
+          </div>
+        )}
+      </div>
+      <div style={{ position: 'relative' }}>{children}</div>
+    </div>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,12 @@ export { Demo } from './Demo';
 export { createStep } from './Step';
 export { useDemo } from './DemoContext';
 export * from './components/cursors';
-export type { 
-  DemoProps, 
-  DemoStep, 
-  CursorAction, 
+export { MockBrowser } from './MockBrowser';
+export type { BrowserType } from './MockBrowser';
+export type {
+  DemoProps,
+  DemoStep,
+  CursorAction,
   ScrollAction,
   DemoContextType
-} from './types'; 
+} from './types';


### PR DESCRIPTION
## Summary
- add `MockBrowser` component to render demo steps inside a fake browser
- export new component and type from library
- add BrowserDemo tab to examples
- update README task list

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f4cda22188322a548fcff617ad200